### PR TITLE
Fix code generation when textureProjLod is used.

### DIFF
--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -900,7 +900,7 @@ void ir_print_glsl_visitor::visit(ir_texture *ir)
 
 	if (is_array && state->EXT_texture_array_enable)
 		buffer.asprintf_append ("Array");
-	if (ir->op == ir_tex && is_proj)
+	if ((ir->op == ir_tex || ir->op == ir_txl) && is_proj)
 		buffer.asprintf_append ("Proj");
 	if (ir->op == ir_txl)
 		buffer.asprintf_append ("Lod");


### PR DESCRIPTION
  Hi @bkaradzic,
  It seems there is a problem with the `textureProjLod` function (tested with `sampler2DShadow`): after the execution of glsl-optimizer the function turns into `textureLod`. This fix solves the problem on my side. :slightly_smiling_face: 
  
  I suppose this function is rarely used and the code generation is broken since this commit: https://github.com/bkaradzic/glsl-optimizer/commit/d70afdbc9aefe22b7462c8e1b801b0a74498030e#diff-5b3ef514acc7f5830afaf7e88d13482ceea98bc6ace089d3c34a02f15cce0373R893