### PR TITLE
Implement csel printing

### DIFF
--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -756,6 +756,16 @@ void ir_print_glsl_visitor::visit(ir_expression *ir)
 			buffer.asprintf_append (")");
 		}
 	}
+	else if (ir->operation == ir_triop_csel)
+	{
+		buffer.asprintf_append ("mix(");
+		ir->operands[2]->accept(this);
+		buffer.asprintf_append (", ");
+		ir->operands[1]->accept(this);
+		buffer.asprintf_append (", bvec%d(", ir->operands[1]->type->vector_elements);
+		ir->operands[0]->accept(this);
+		buffer.asprintf_append ("))");
+	}
 	else if (ir->operation == ir_binop_vector_extract)
 	{
 		// a[b]


### PR DESCRIPTION
This PR fixes this use case: https://github.com/aras-p/glsl-optimizer/issues/73

I am not sure if we have to do much more somewhere else to not generate a symbol `csel_TODO` but the code itself makes sense in order to generate the correct shader code when compiled.

Let me know if anything else is missing to make this PR atomic and feature complete.